### PR TITLE
Back channel in notifications, clean up interfaces and println

### DIFF
--- a/modules/lsp/src/main/scala/ImmutableLSPBuilder.scala
+++ b/modules/lsp/src/main/scala/ImmutableLSPBuilder.scala
@@ -19,9 +19,11 @@ case class ImmutableLSPBuilder[F[_]: Monadic] private (
 ) extends LSPBuilder[F]:
 
   override def handleNotification[X <: LSPNotification](t: X)(
-      f: t.In => F[Unit]
+      f: (t.In, Communicate[F]) => F[Unit]
   ) = copy(
-    endpoints = endpoints :+ jsonrpcIntegration.handlerToNotification(t)(f)
+    endpoints = endpoints :+ jsonrpcIntegration.handlerToNotification(t) { in =>
+      f(in, notifyDelegate)
+    }
   )
 
   override def handleRequest[X <: LSPRequest](t: X)(

--- a/modules/lsp/src/main/scala/JSONRPC.scala
+++ b/modules/lsp/src/main/scala/JSONRPC.scala
@@ -13,14 +13,12 @@ private[lsp] object jsonrpcIntegration:
       override def decode(
           payload: Option[Payload]
       ): Either[ProtocolError, T] =
-        System.err.println(s"Decoding $payload")
         payload
           .map(_.array)
           .flatMap { arr =>
             Try(read[T](arr, trace = true)).toOption
           }
           .toRight(ProtocolError.InvalidParams("oopsie daisy"))
-          .tap(System.err.println(_))
       end decode
 
       override def encode(a: T): Payload =

--- a/modules/lsp/src/main/scala/LSPBuilder.scala
+++ b/modules/lsp/src/main/scala/LSPBuilder.scala
@@ -69,12 +69,12 @@ trait LSPBuilder[F[_]]:
   ): LSPBuilder[F]
 
   def handleNotification[X <: LSPNotification](t: X)(
-      f: t.In => F[Unit]
+      f: (t.In, Communicate[F]) => F[Unit]
   ): LSPBuilder[F]
 
   def build(comm: Communicate[F]): List[Endpoint[F]]
 
-  def bind(channel: Channel[F])(using Monadic[F]): F[Channel[F]] =
+  def bind[T <: Channel[F]](channel: T)(using Monadic[F]): F[T] =
     val Fm        = summon[Monadic[F]]
     val endpoints = build(Communicate.channel(channel))
 

--- a/modules/lsp/src/main/scala/json.scala
+++ b/modules/lsp/src/main/scala/json.scala
@@ -163,7 +163,6 @@ object Pickle:
     // else reader
 
     case m: Mirror.SumOf[T] =>
-      println("OH NO")
       inline compiletime.erasedValue[T] match
         case _: scala.reflect.Enum =>
           val valueOf     = macros.enumValueOf[T]


### PR DESCRIPTION
1. Remove spurious printlns
2. Pass `Communicate[F]` to notifications as well - i.e. `didOpen` is a notification to which you might want to respond with diagnostics
3. Take a Channel subtype - has better ergonomics when you bind to, say, FS2Channel and want to continue working with it