### PR TITLE
Fix flickering

### DIFF
--- a/modules/tracer/frontend/src/main/scala/component.timeline.scala
+++ b/modules/tracer/frontend/src/main/scala/component.timeline.scala
@@ -26,7 +26,6 @@ def timeline(
   val splitStream =
     filteredMessages
       .split(e => uniqueId(e))(renderMessage(showing))
-      .debugSpyEvents(els => println(els.length))
 
   div(
     display.flex,

--- a/modules/tracer/frontend/src/main/scala/page.commands.scala
+++ b/modules/tracer/frontend/src/main/scala/page.commands.scala
@@ -23,9 +23,9 @@ def commandTracer(
         .debounce(500)
         .startWith(Date.now())
         .flatMap { _ =>
-          Signal
+          EventStream
             .fromFuture(Api.all)
-            .map(_.toVector.flatten.reverse)
+            .map(_.reverse)
         } --> messagesState.writer,
       timeline(messagesState, commandFilter, showing)
     )


### PR DESCRIPTION
+ Break up the functions a little bit

The main issue was using `Signal.fromFuture` - it returns `Option[...]`, which we flatten.
That means that during loading, the first emitted value is None, which means that for a very short amount of time we write an empty vector of messages into the `Var` - which would cause a very fast re-render of the entire timeline

Closes #34 