### PR TITLE
Render And types in requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'sbt'
 
       - name: Test
-        run: sbt --client 'ci; publishLocal; lsp/doc'
+        run: sbt --client 'ci; publishLocal'
 
       - name: Publish ${{ github.ref }}
         if: startsWith(github.ref, 'refs/tags/v') 
@@ -44,7 +44,9 @@ jobs:
 
       - name: Build API doc
         if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main')
-        run: sbt --client "lsp/doc"
+        run: sbt "lsp/doc"
+        env: 
+          USE_SCALA_NIGHTLY: true
 
       - name: Publish gh-pages
         if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ inThisBuild(
 )
 
 val V = new {
-  val scala      = "3.2.0"
+  val scala      = "3.1.3"
   val scribe     = "3.10.3"
   val upickle    = "2.0.0"
   val cats       = "2.8.0"

--- a/build.sbt
+++ b/build.sbt
@@ -30,11 +30,11 @@ inThisBuild(
 )
 
 val V = new {
-  val scala      = "3.1.3"
+  val scala      = "3.2.0"
   val scribe     = "3.10.3"
   val upickle    = "2.0.0"
   val cats       = "2.8.0"
-  val verify     = "1.0.0"
+  val munit      = "1.0.0-M6"
   val jsonrpclib = "0.0.3"
   val fs2        = "3.2.12"
   val http4s     = "0.23.15"
@@ -79,13 +79,12 @@ lazy val lsp = projectMatrix
   .settings(
     name := "langoustine-lsp",
     scalacOptions ++= Seq("-Xmax-inlines", "64"),
-    libraryDependencies += "com.eed3si9n.verify" %%% "verify" % V.verify % Test,
-    testFrameworks += new TestFramework("verify.runner.Framework"),
-    Test / fork := virtualAxes.value.contains(VirtualAxis.jvm),
-    libraryDependencies += "com.outr"      %%% "scribe"          % V.scribe,
-    libraryDependencies += "com.lihaoyi"   %%% "upickle"         % V.upickle,
-    libraryDependencies += "org.typelevel" %%% "cats-core"       % V.cats,
-    libraryDependencies += "tech.neander"  %%% "jsonrpclib-core" % V.jsonrpclib
+    libraryDependencies += "org.scalameta" %%% "munit"     % V.munit % Test,
+    libraryDependencies += "com.outr"      %%% "scribe"    % V.scribe,
+    libraryDependencies += "com.lihaoyi"   %%% "upickle"   % V.upickle,
+    libraryDependencies += "org.typelevel" %%% "cats-core" % V.cats,
+    libraryDependencies += "tech.neander" %%% "jsonrpclib-core" % V.jsonrpclib,
+    Test / fork := virtualAxes.value.contains(VirtualAxis.jvm)
   )
   .jvmPlatform(scalaVersions)
   .jsPlatform(scalaVersions)

--- a/modules/lsp/src/main/scala/generated/codecs.scala
+++ b/modules/lsp/src/main/scala/generated/codecs.scala
@@ -1056,13 +1056,19 @@ private[lsp] trait requests_workspace_codeLens_refresh:
   given outputReader: Reader[Out] =
     nullReadWriter
 
+private[lsp] trait requests_workspace_configuration_WorkspaceConfigurationInput:
+  import requests.workspace.configuration.*
+  private[lsp] given reader: Reader[requests.workspace.configuration.WorkspaceConfigurationInput] = Pickle.macroR
+  private[lsp] given writer: Writer[requests.workspace.configuration.WorkspaceConfigurationInput] = upickle.default.macroW
+
+
 private[lsp] trait requests_workspace_configuration:
   import workspace.configuration.{In, Out}
   given inputReader: Reader[In] = 
-    ??? /* TODO: AndType(Vector(ReferenceType(ConfigurationParams), ReferenceType(PartialResultParams)))  */
+    workspace.configuration.WorkspaceConfigurationInput.reader
   
   given inputWriter: Writer[In] = 
-    ???
+    workspace.configuration.WorkspaceConfigurationInput.writer
   
   given outputWriter: Writer[Out] =
     vectorWriter[ujson.Value]

--- a/modules/lsp/src/main/scala/generated/requests.scala
+++ b/modules/lsp/src/main/scala/generated/requests.scala
@@ -733,9 +733,21 @@ object requests:
      *  change event and empty the cache if such an event is received.
      */
     object configuration extends LSPRequest("workspace/configuration") with codecs.requests_workspace_configuration:
-      type In = Any /*AndType(Vector(ReferenceType(ConfigurationParams), ReferenceType(PartialResultParams)))*/
+      type In = WorkspaceConfigurationInput
       type Out = Vector[ujson.Value]
       
+      /**
+       *  @param items
+       *  @param partialResultToken
+       *    An optional token that a server can use to report partial results (e.g. streaming) to
+       *    the client.
+      
+       */
+      case class WorkspaceConfigurationInput(
+        items: Vector[structures.ConfigurationItem],
+        partialResultToken: Opt[aliases.ProgressToken] = Opt.empty
+      )
+      object WorkspaceConfigurationInput extends codecs.requests_workspace_configuration_WorkspaceConfigurationInput
     
     /**
      *  The workspace diagnostic request definition.

--- a/modules/lsp/src/main/scala/newtype.scala
+++ b/modules/lsp/src/main/scala/newtype.scala
@@ -58,5 +58,7 @@ private[lsp] abstract class YesNo[A](using ev: Boolean =:= A):
 
   inline def apply(inline b: Boolean): A = ev.apply(b)
 
-  extension (inline a: A) inline def value: Boolean = a == Yes
+  extension (inline a: A)
+    inline def value: Boolean = a == Yes
+    inline def yes: Boolean   = a == Yes
 end YesNo

--- a/modules/lsp/src/test/scala/CodecTest.scala
+++ b/modules/lsp/src/test/scala/CodecTest.scala
@@ -9,8 +9,8 @@ import cats.Monad
 
 import jsonrpclib.*
 
-object CodecTest extends verify.BasicTestSuite:
-  test("test documentSymbol codec") {
+class CodecTest() extends munit.FunSuite:
+  test("documentSymbol codec") {
 
     val out1 = Opt(
       Vector(
@@ -54,6 +54,19 @@ object CodecTest extends verify.BasicTestSuite:
 
     assertEquals(read1.toString, out1.toString)
     assertEquals(read2.toString, out2.toString)
+
+  }
+
+  test("workspace/configuration codec (and types construction)") {
+    val req = workspace.configuration
+    val in = workspace.configuration.WorkspaceConfigurationInput(
+      items = Vector(ConfigurationItem(Opt("hello"))),
+      partialResultToken = Opt(ProgressToken("helllooooo"))
+    )
+
+    import req.WorkspaceConfigurationInput
+
+    assertEquals(read[WorkspaceConfigurationInput](write(in)), in)
 
   }
 end CodecTest

--- a/modules/lsp/src/test/scala/LSPSuite.scala
+++ b/modules/lsp/src/test/scala/LSPSuite.scala
@@ -12,7 +12,7 @@ def basicServer[F[_]: Monadic] =
 
 import jsonrpclib.*
 
-object LSPSuite extends verify.BasicTestSuite:
+class LSPSuite() extends munit.FunSuite:
   test("initialize") {
 
     import requests.*

--- a/modules/meta/src/main/scala/Manager.scala
+++ b/modules/meta/src/main/scala/Manager.scala
@@ -40,5 +40,8 @@ class Manager(mm: MetaModel):
     notifications
   }
 
-  def get(s: String) = index.get(s)
+  def get(
+      s: String
+  ): Option[Enumeration | TypeAlias | Structure | Request | Notification] =
+    index.get(s)
 end Manager

--- a/modules/meta/src/main/scala/newtype.scala
+++ b/modules/meta/src/main/scala/newtype.scala
@@ -56,5 +56,8 @@ abstract class YesNo[A](using ev: Boolean =:= A):
 
   inline def apply(inline b: Boolean): A = ev.apply(b)
 
-  extension (inline a: A) inline def value: Boolean = a == Yes
+  extension (inline a: A)
+    inline def value: Boolean = a == Yes
+    inline def yes: Boolean   = a == Yes
+    inline def no: Boolean    = !yes
 end YesNo


### PR DESCRIPTION
Closes #32 

1. And types are translated into a structure with several mixins. As such, this only works for 
2. Changes to munit, because of the macro issues in Verify that I don't have the time to fix upstream
3. (dangerously stupid) use Scala Nightly to generate Scaladoc because I like the design so much...