### PR TITLE
Make bind host configurable

### DIFF
--- a/docs/_docs/tracer.md
+++ b/docs/_docs/tracer.md
@@ -60,6 +60,17 @@ By default, it will start the server at random port, but you can change that usi
 langoustine-tracer --port 9911 my-awesome lsp --stdin true
 ```
 
+### Changing host
+
+By default, tracer will bind to `localhost`. On some systems this may cause issues,
+for example under WSL on Windows.
+
+In this scenario you might want to change the host to `0.0.0.0` with the `--host` parameter:
+
+```
+langoustine-tracer --host 0.0.0.0 my-awesome lsp --stdin true
+```
+
 ### Local development
 
 If you are working on the tracer itself, you can globally alias `langoustine-tracer` to a local installation:

--- a/modules/tests/src/test/scalajvm/tracer/ServerSpec.scala
+++ b/modules/tests/src/test/scalajvm/tracer/ServerSpec.scala
@@ -16,6 +16,8 @@ import org.http4s.Uri
 import org.http4s.client.websocket.*
 import cats.data.NonEmptyList
 
+import com.comcast.ip4s.*
+
 abstract class ServerSpec extends IOSuite:
   type Res = Feed
   override def sharedResource: Resource[cats.effect.IO, Res] =
@@ -30,7 +32,7 @@ abstract class ServerSpec extends IOSuite:
             err = err.stream.unchunks
           )
           .runResource(
-            Config(9914, NonEmptyList.of("echo")),
+            Config.create(NonEmptyList.of("echo")),
             Summary(System.getProperty("user.dir"), List("echo", "world"))
           )
 

--- a/modules/tests/src/test/scalajvm/tracer/TracerCLISpec.scala
+++ b/modules/tests/src/test/scalajvm/tracer/TracerCLISpec.scala
@@ -1,0 +1,52 @@
+package tests.tracer
+
+import langoustine.tracer.*
+import cats.effect.IO
+import cats.data.NonEmptyList
+
+import com.comcast.ip4s.*
+import langoustine.tracer.Config.Defaults
+
+object TracerCLISpec extends weaver.SimpleIOSuite:
+  val lspCommand = NonEmptyList.of("launch", "me")
+
+  pureTest("CLI rejects invalid port") {
+    expect.all(
+      Config.command.parse(Seq("--port", "-1000") ++ lspCommand.toList).isLeft,
+      Config.command.parse(Seq("--port", "hello") ++ lspCommand.toList).isLeft,
+      Config.command
+        .parse(
+          Seq(
+            "--port",
+            (Integer.MAX_VALUE.toLong * 2).toString
+          ) ++ lspCommand.toList
+        )
+        .isLeft
+    )
+  }
+
+  pureTest("CLI rejects invalid host") {
+    expect.all(
+      Config.command
+        .parse(Seq("--host", "123,123,123") ++ lspCommand.toList)
+        .isLeft,
+      Config.command
+        .parse(Seq("--host", "/asd/ads/ads") ++ lspCommand.toList)
+        .isLeft,
+      Config.command.parse(Seq("--host", "") ++ lspCommand.toList).isLeft,
+      Config.command
+        .parse(Seq("--host", "-12312312") ++ lspCommand.toList)
+        .isLeft
+    )
+  }
+
+  pureTest("CLI sets expected defaults") {
+    val withDefaults = Config.command.parse(lspCommand.toList)
+
+    expect.all(
+      withDefaults.map(_.port) == Right(Defaults.port),
+      withDefaults.map(_.host) == Right(Defaults.host),
+      withDefaults.map(_.cmd) == Right(lspCommand)
+    )
+  }
+end TracerCLISpec

--- a/modules/tests/src/test/scalajvm/tracer/TracerLauncherSpec.scala
+++ b/modules/tests/src/test/scalajvm/tracer/TracerLauncherSpec.scala
@@ -8,7 +8,7 @@ import langoustine.tracer.*
 object TracerLauncherSpec extends SimpleIOSuite:
   test("doesn't start the server if process fails") {
     Launch(
-      Config(-12315123, NonEmptyList.of("!@£!WIIACSNN£!)(ASNDASD"))
+      Config.create(NonEmptyList.of("!@£!WIIACSNN£!)(ASNDASD"))
     ).attempt.map { result =>
       expect(result.isLeft)
     }

--- a/modules/tracer/backend/src/main/scala/Config.scala
+++ b/modules/tracer/backend/src/main/scala/Config.scala
@@ -20,7 +20,7 @@ object Config:
 
   object Defaults:
     val port = port"0"
-    val host = host"0.0.0.0"
+    val host = host"localhost"
 
   private val portOpt =
     Opts

--- a/modules/tracer/backend/src/main/scala/Config.scala
+++ b/modules/tracer/backend/src/main/scala/Config.scala
@@ -3,20 +3,50 @@ package langoustine.tracer
 import cats.implicits.*
 import com.monovore.decline.*
 import cats.data.NonEmptyList
+import com.comcast.ip4s.*
 
-case class Config(port: Int, cmd: NonEmptyList[String])
+case class Config(port: Port, host: Host, cmd: NonEmptyList[String])
 
 object Config:
+  /** Create a config instance with all optional parameters set to their default
+    * values
+    *
+    * @param lspCommand
+    * @return
+    *   config
+    */
+  def create(lspCommand: NonEmptyList[String]): Config =
+    Config(Defaults.port, Defaults.host, lspCommand)
 
-  val portOpt =
-    val portHelo = "Port to start Tracer on"
+  object Defaults:
+    val port = port"0"
+    val host = host"0.0.0.0"
+
+  private val portOpt =
     Opts
-      .option[Int]("port", portHelo)
-      .withDefault(0)
+      .option[Int](
+        "port",
+        "Port to bind tracer to - by default a random port will be selected"
+      )
+      .mapValidated { portNumber =>
+        Port.fromInt(portNumber).toValidNel("Invalid port number")
+      }
+      .withDefault(Defaults.port)
 
-  val lsp = Opts.arguments[String]("lspCommand")
+  private val hostOpt =
+    Opts
+      .option[String](
+        "host",
+        s"Host to bind tracer to - by default ${Defaults.host} is used"
+      )
+      .mapValidated { hostRaw =>
+        Host.fromString(hostRaw).toValidNel("Invalid host")
+      }
+      .withDefault(Defaults.host)
 
-  val config = (portOpt, lsp).mapN(Config.apply)
+  private val lspOpt = Opts.arguments[String]("lspCommand")
+
+  private val config = (portOpt, hostOpt, lspOpt).mapN(Config.apply)
 
   val command = Command(
     name = "tracer",

--- a/modules/tracer/backend/src/main/scala/TracerServer.scala
+++ b/modules/tracer/backend/src/main/scala/TracerServer.scala
@@ -183,10 +183,8 @@ class TracerServer private (
   ): Resource[cats.effect.IO, server.Server] =
     EmberServerBuilder
       .default[IO]
-      .withPort(
-        Port.fromInt(config.port).get
-      )
-      .withHost(host"localhost")
+      .withPort(config.port)
+      .withHost(config.host)
       .withShutdownTimeout(1.second)
       .withHttpWebSocketApp(app)
       .build


### PR DESCRIPTION
Closes #70 

Originally I planned to make it bind to 0.0.0.0 by default, but this turned out to be a bad idea because it causes complaints from my browser that enforces SSL:

![image](https://user-images.githubusercontent.com/1052965/190991245-806dd5eb-f3dd-4f85-aff8-c193d1a5fd56.png)

Which makes for a jarring experience.

To alleviate the pain point, we stay binding to localhost, but allow the user to set `--host` parameter on systems that don't work with localhost

Also:

- Configurable --host parameter
- Basic CLI config tests