### PR TITLE
WIP: provide WebSocket support via http4s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ lazy val root = project
   .aggregate(meta.projectRefs*)
   .aggregate(lsp.projectRefs*)
   .aggregate(app.projectRefs*)
+  .aggregate(http4s.projectRefs*)
   .aggregate(tracer.projectRefs*)
   .aggregate(tracerShared.projectRefs*)
   .aggregate(tracerFrontend.projectRefs*)
@@ -142,6 +143,21 @@ lazy val app = projectMatrix
     libraryDependencies += "tech.neander" %%% "jsonrpclib-fs2" % V.jsonrpclib,
     libraryDependencies += "co.fs2"       %%% "fs2-io"         % V.fs2,
     libraryDependencies += "com.outr"     %%% "scribe-cats"    % V.scribe,
+    test                                   := {}
+  )
+  .jvmPlatform(V.scalaVersions)
+  .jsPlatform(V.scalaVersions)
+  .nativePlatform(V.scalaVersions)
+
+lazy val http4s = projectMatrix
+  .in(file("modules/http4s"))
+  .dependsOn(lsp)
+  .defaultAxes(V.default*)
+  .settings(enableSnapshots)
+  .settings(
+    name                                   := "langoustine-http4s",
+    libraryDependencies += "tech.neander" %%% "jsonrpclib-fs2" % V.jsonrpclib,
+    libraryDependencies += "org.http4s"   %%% "http4s-core"    % V.http4s,
     test                                   := {}
   )
   .jvmPlatform(V.scalaVersions)
@@ -365,14 +381,14 @@ import sbtwelcome.*
 
 logo :=
   raw"""
-    |    _                                       _   _            
-    |   | |                                     | | (_)           
-    |   | |     __ _ _ __   __ _  ___  _   _ ___| |_ _ _ __   ___ 
+    |    _                                       _   _
+    |   | |                                     | | (_)
+    |   | |     __ _ _ __   __ _  ___  _   _ ___| |_ _ _ __   ___
     |   | |    / _` | '_ \ / _` |/ _ \| | | / __| __| | '_ \ / _ \
     |   | |___| (_| | | | | (_| | (_) | |_| \__ \ |_| | | | |  __/
     |   |______\__,_|_| |_|\__, |\___/ \__,_|___/\__|_|_| |_|\___|
-    |                       __/ |                                 
-    |                      |___/                                  
+    |                       __/ |
+    |                      |___/
     |
     |${version.value}
     |

--- a/modules/http4s/src/main/scala/WebSocketServer.scala
+++ b/modules/http4s/src/main/scala/WebSocketServer.scala
@@ -1,0 +1,42 @@
+package langoustine.http4s
+
+import org.http4s.websocket.WebSocketFrame
+import cats.effect.Concurrent
+import fs2.Stream
+import fs2.Pipe
+import langoustine.lsp.LSPBuilder
+import jsonrpclib.Channel
+import jsonrpclib.fs2.FS2Channel
+import cats.effect.kernel.Deferred
+import cats.syntax.all.*
+import jsonrpclib.fs2.*
+import jsonrpclib.fs2.given
+import jsonrpclib.Payload
+import scodec.bits.ByteVector
+
+object WebSocketServer:
+  def make[F[_]: Concurrent](
+      builder: LSPBuilder[F],
+      bufferSize: Int
+  ): Pipe[F, WebSocketFrame, WebSocketFrame] = inputFrames =>
+    Stream
+      .eval(Deferred[F, Boolean])
+      .flatMap { latch =>
+        FS2Channel(bufferSize, None)
+          .flatMap { channel =>
+            Stream.eval(builder.bind(channel, latch.complete(true).void))
+          }
+          .flatMap { channel =>
+            channel.output
+              .map(p => WebSocketFrame.Text(ByteVector(p.array)))
+              .concurrently(
+                inputFrames
+                  .map(frame => Payload(frame.data.toArray))
+                  .through(channel.input)
+              )
+              .interruptWhen(Stream.eval(latch.get))
+
+          }
+      }
+
+end WebSocketServer


### PR DESCRIPTION
At the moment, usage looks like this:

```scala
// in IOApp
override def run(
  args: List[String]
): IO[ExitCode] = {
  import com.comcast.ip4s._
  EmberServerBuilder
    .default[IO]
    .withPort(port"30000")
    .withHttpWebSocketApp { ws =>
      HttpApp.liftF {
        ws.build { in =>
          fs2
            .Stream
            .resource(mkServer)
            .flatMap {
              langoustine.http4s.WebSocketServer.make(_, bufferSize = 2048).apply(in)
            }
        }
      }
    }
    .build
    .useForever
}

def mkServer: Resource[IO, LSPBuilder[IO]]
```

Perhaps something like a `WebSocketLangoustineApp` should also be provided, but I suppose people might want to have the ability to configure `WebSocketBuilder2` on their own.