### PR TITLE
Better reporting for json read failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,12 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin' 
-          java-version: '17'
-          cache: 'sbt'
+          distribution: "temurin"
+          java-version: "17"
+          cache: "sbt"
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Test
         run: sbt ci buildWebsite


### PR DESCRIPTION
I was trying to debug an issue in which my lsp4j client was sending an invalid response (but I didn't know what, because Java and nulls of course) - turned out to have been a missing `capabilities`, having this in the error helped. Without this, the error was being lost by `Try#toOption`.

Do we need a test for this?