### PR TITLE
Simplify enum names code

### DIFF
--- a/modules/generate/src/main/scala/render.scala
+++ b/modules/generate/src/main/scala/render.scala
@@ -1162,12 +1162,8 @@ class Render(manager: Manager, packageName: String = "langoustine.lsp"):
               )
               nest {
                 a.values.foreach { entry =>
-                  val lhs = base match
-                    case ET.string => '"' + entry.value.stringValue + '"'
-                    case _         => entry.value.intValue.toString
-
                   line(
-                    s"case $lhs => \"${entry.name}\""
+                    s"case ${entry.value.intValue} => \"${entry.name}\""
                   )
                 }
               }


### PR DESCRIPTION
Small update to #201, I originally rendered a pattern match for strings too so a tiny bit of extra complexity stayed there that's no longer necessary.