### PR TITLE
30 minutes should be enough for everyone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
10 minutes [wasn't quite enough](https://github.com/neandertech/langoustine/actions/runs/15012811131/job/42184539516) for publishing, so let's try 30. It's still nowhere near the default of 6 hours.