### PR TITLE
Support cancellation in LangoustineApp

### DIFF
--- a/modules/app/src/main/scala/LSPCancelRequest.scala
+++ b/modules/app/src/main/scala/LSPCancelRequest.scala
@@ -1,0 +1,21 @@
+package langoustine.lsp.app
+
+import jsonrpclib.CallId
+import jsonrpclib.Codec
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import jsonrpclib.fs2.CancelTemplate
+
+private case class LSPCancelRequest(id: CallId)
+
+object LSPCancelRequest:
+  import com.github.plokhotnyuk.jsoniter_scala.macros.*
+  given JsonValueCodec[LSPCancelRequest] = JsonCodecMaker.make[LSPCancelRequest]
+  given Codec[LSPCancelRequest]          = Codec.fromJsonCodec
+
+  val cancelTemplate: CancelTemplate = CancelTemplate
+    .make[LSPCancelRequest](
+      "$/cancelRequest",
+      _.id,
+      LSPCancelRequest(_)
+    )
+end LSPCancelRequest

--- a/modules/app/src/main/scala/LSPCancelRequest.scala
+++ b/modules/app/src/main/scala/LSPCancelRequest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package langoustine.lsp.app
 
 import jsonrpclib.CallId

--- a/modules/app/src/main/scala/LangoustineApp.scala
+++ b/modules/app/src/main/scala/LangoustineApp.scala
@@ -131,7 +131,7 @@ object LangoustineApp:
     fs2.Stream
       .eval(IO.deferred[Boolean])
       .flatMap { latch =>
-        FS2Channel[IO](bufferSize, None)
+        FS2Channel[IO](bufferSize, Some(LSPCancelRequest.cancelTemplate))
           .flatMap { channel =>
             (builder: @unchecked) match
               case l: LSPBuilder[IO] =>

--- a/modules/e2e-tests/src/test/scala/EndToEndTests.scala
+++ b/modules/e2e-tests/src/test/scala/EndToEndTests.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.e2e
 
 import langoustine.lsp.all.*

--- a/modules/tests/src/test/scala/CodecTest.scala
+++ b/modules/tests/src/test/scala/CodecTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.core
 
 import upickle.default.*

--- a/modules/tests/src/test/scala/DeriveScalacheckArbitrary.scala
+++ b/modules/tests/src/test/scala/DeriveScalacheckArbitrary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.core
 
 import langoustine.lsp.runtime.*

--- a/modules/tests/src/test/scala/LSPTests.scala
+++ b/modules/tests/src/test/scala/LSPTests.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.core
 
 import langoustine.lsp.*

--- a/modules/tests/src/test/scala/RuntimeTest.scala
+++ b/modules/tests/src/test/scala/RuntimeTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.runtime
 
 import langoustine.lsp.runtime.*

--- a/modules/tests/src/test/scala/SnapshotsIntegration.scala
+++ b/modules/tests/src/test/scala/SnapshotsIntegration.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.core
 
 import weaver.Expectations

--- a/modules/tests/src/test/scala/testkit.scala
+++ b/modules/tests/src/test/scala/testkit.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.core
 
 import langoustine.lsp.*

--- a/modules/tests/src/test/scala/tools/SemanticTokenTest.scala
+++ b/modules/tests/src/test/scala/tools/SemanticTokenTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.lsp
 
 import langoustine.lsp.tools.SemanticTokensEncoder

--- a/modules/tests/src/test/scala/tools/SemanticTokensEncoderTest.scala
+++ b/modules/tests/src/test/scala/tools/SemanticTokensEncoderTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.lsp
 
 import langoustine.lsp.tools.SemanticTokensEncoder

--- a/modules/tests/src/test/scalajvm/tracer/Feed.scala
+++ b/modules/tests/src/test/scalajvm/tracer/Feed.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.tracer
 
 import weaver.*

--- a/modules/tests/src/test/scalajvm/tracer/Front.scala
+++ b/modules/tests/src/test/scalajvm/tracer/Front.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.tracer
 
 import weaver.*

--- a/modules/tests/src/test/scalajvm/tracer/ProtocolSpec.scala
+++ b/modules/tests/src/test/scalajvm/tracer/ProtocolSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.tracer
 
 import weaver.*

--- a/modules/tests/src/test/scalajvm/tracer/ServerSpec.scala
+++ b/modules/tests/src/test/scalajvm/tracer/ServerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.tracer
 
 import cats.effect.*

--- a/modules/tests/src/test/scalajvm/tracer/TracerCLISpec.scala
+++ b/modules/tests/src/test/scalajvm/tracer/TracerCLISpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.tracer
 
 import langoustine.tracer.*

--- a/modules/tests/src/test/scalajvm/tracer/TracerLauncherSpec.scala
+++ b/modules/tests/src/test/scalajvm/tracer/TracerLauncherSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.tracer
 
 import weaver.*

--- a/modules/tests/src/test/scalajvm/tracer/TracerServerSpec.scala
+++ b/modules/tests/src/test/scalajvm/tracer/TracerServerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.tracer
 
 import langoustine.tracer.*

--- a/modules/tests/src/test/scalajvm/tracer/TracerSnapshotSpec.scala
+++ b/modules/tests/src/test/scalajvm/tracer/TracerSnapshotSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Neandertech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tests.tracer
 
 import langoustine.tracer.*


### PR DESCRIPTION
- Adding the missing cancel template
- notably the input of the `$/cancelRequest` endpoint is a `CallId` nested under `.id`, which wasn't easy to spot when jsonrpclib gives you examples with `$/cancel` and a direct `CallId` body: https://github.com/neandertech/jsonrpclib/blob/a482091ed628e3fba23350b73c602d5b287f695c/modules/examples/server/src/main/scala/examples/server/ServerMain.scala#L14

Tests: "works on my machine", real tests can be added in #212